### PR TITLE
Add test block_gap

### DIFF
--- a/tests/block_gaps.sql
+++ b/tests/block_gaps.sql
@@ -1,0 +1,22 @@
+WITH silver_blocks AS (
+  SELECT
+    block_id,
+    block_timestamp,
+    block_hash,
+    prev_hash,
+    LAG(block_hash) over (
+      ORDER BY
+        block_timestamp ASC,
+        block_id ASC
+    ) AS prior_hash
+  FROM
+    {{ ref('silver__blocks') }}
+  WHERE
+    block_timestamp < CURRENT_DATE - 1
+)
+SELECT
+  *
+FROM
+  silver_blocks
+WHERE
+  prior_hash <> prev_hash


### PR DESCRIPTION
# Description

Adds a test to compare prev_hash to the prior hash as based on the block_timestamp and block id order, does not look at `block_timestamp < CURRENT_DATE - 1` as most of the errors are recent and look to be self correcting.

No tables are changed

Did not add this as a macro as this is specific to silver blocks, (bronze does not have prev_hash without looking at the header). And will run with a generic dbt test

# Tests

- [ ] Please provide evidence of your successful `dbt run` / `dbt test` here
- - test is not successful which in itself is a success 
- [ ] Any comparison between `prod` and `dev` for any schema change
# Checklist
- [ ] Follow [dbt style guide](https://github.com/dbt-labs/corp/blob/main/dbt_style_guide.md)
- [ ] Tag the person(s) responsible for reviewing proposed changes
- #
- [ ] Notes to deployment, if a `full-refresh` is needed for any table
- [ ] Run `git merge main` to pull any changes from remote into your branch prior to merge.

![image](https://user-images.githubusercontent.com/3936021/190937852-a4ad2b32-5ccf-4e6c-8f44-ab773285d762.png)

